### PR TITLE
Add a timeout of 20 seconds to all executed commands.

### DIFF
--- a/git.go
+++ b/git.go
@@ -20,7 +20,7 @@ func (git) Status(dir string) (string, error) {
 	cmd := exec.Command("git", "status", "--porcelain")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +31,7 @@ func (git) Branch(dir string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func (v git) LocalRevision(dir string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", v.defaultBranch())
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +60,7 @@ func (git) Stash(dir string) (string, error) {
 	cmd := exec.Command("git", "stash", "list")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func (v git) Contains(dir string, revision string) (bool, error) {
 	cmd := exec.Command("git", "branch", "--list", "--contains", revision, v.defaultBranch())
 	cmd.Dir = dir
 
-	stdout, stderr, err := dividedOutput(cmd)
+	stdout, stderr, err := dividedOutputTimeout(cmd)
 	switch {
 	case err == nil:
 		// If this commit is contained, the expected output is exactly "* master\n" or "  master\n" if we're on another branch.
@@ -108,7 +108,7 @@ func (git) RemoteURL(dir string) (string, error) {
 	cmd := exec.Command("git", "ls-remote", "--get-url", "origin")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -124,7 +124,7 @@ func (v git) RemoteRevision(dir string) (string, error) {
 	env.Set("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=yes") // Default for StrictHostKeyChecking is "ask", which we don't want since v is non-interactive and we prefer to fail than block asking for user input.
 	cmd.Env = env
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/hg.go
+++ b/hg.go
@@ -18,7 +18,7 @@ func (hg) Status(dir string) (string, error) {
 	cmd := exec.Command("hg", "status")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -29,7 +29,7 @@ func (hg) Branch(dir string) (string, error) {
 	cmd := exec.Command("hg", "branch")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -43,7 +43,7 @@ func (v hg) LocalRevision(dir string) (string, error) {
 	cmd := exec.Command("hg", "--debug", "identify", "-i", "--rev", v.defaultBranch())
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +57,7 @@ func (hg) Stash(dir string) (string, error) {
 	cmd := exec.Command("hg", "shelve", "--list")
 	cmd.Dir = dir
 
-	stdout, stderr, err := dividedOutput(cmd)
+	stdout, stderr, err := dividedOutputTimeout(cmd)
 	switch {
 	case err == nil && len(stdout) != 0:
 		return string(stdout), nil
@@ -74,7 +74,7 @@ func (v hg) Contains(dir string, revision string) (bool, error) {
 	cmd := exec.Command("hg", "log", "--branch", v.defaultBranch(), "--rev", revision)
 	cmd.Dir = dir
 
-	stdout, stderr, err := dividedOutput(cmd)
+	stdout, stderr, err := dividedOutputTimeout(cmd)
 	switch {
 	case err == nil && len(stdout) != 0:
 		return true, nil // Non-zero output means this commit is indeed contained.
@@ -91,7 +91,7 @@ func (hg) RemoteURL(dir string) (string, error) {
 	cmd := exec.Command("hg", "paths", "default")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -102,7 +102,7 @@ func (v hg) RemoteRevision(dir string) (string, error) {
 	cmd := exec.Command("hg", "--debug", "identify", "-i", "--rev", v.defaultBranch(), "default")
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/remotegit.go
+++ b/remotegit.go
@@ -18,7 +18,7 @@ func (v remoteGit) RemoteRevision(remoteURL string) (string, error) {
 	env.Set("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=yes") // Default for StrictHostKeyChecking is "ask", which we don't want since this is non-interactive and we prefer to fail than block asking for user input.
 	cmd.Env = env
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/remotehg.go
+++ b/remotehg.go
@@ -12,7 +12,7 @@ type remoteHg struct{}
 func (v remoteHg) RemoteRevision(remoteURL string) (string, error) {
 	cmd := exec.Command("hg", "--debug", "identify", "-i", "--rev", v.defaultBranch(), remoteURL)
 
-	out, err := cmd.Output()
+	out, err := outputTimeout(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/util.go
+++ b/util.go
@@ -8,7 +8,7 @@ import (
 )
 
 // timeout for running commands. It helps if some remote server stalls and doesn't hang up, etc.
-const timeout = 10 * time.Second
+const timeout = 20 * time.Second
 
 // outputTimeout runs the command and returns its standard output,
 // with a timeout.

--- a/util.go
+++ b/util.go
@@ -3,13 +3,42 @@ package vcsstate
 import (
 	"bytes"
 	"os/exec"
+	"syscall"
+	"time"
 )
 
-// dividedOutput runs the command and returns its standard output and standard error.
-func dividedOutput(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
-	var outb, errb bytes.Buffer
-	cmd.Stdout = &outb
-	cmd.Stderr = &errb
-	err = cmd.Run()
-	return outb.Bytes(), errb.Bytes(), err
+// timeout for running commands. It helps if some remote server stalls and doesn't hang up, etc.
+const timeout = 10 * time.Second
+
+// outputTimeout runs the command and returns its standard output,
+// with a timeout.
+func outputTimeout(cmd *exec.Cmd) ([]byte, error) {
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	err := runTimeout(cmd)
+	return buf.Bytes(), err
+}
+
+// dividedOutputTimeout runs the command and returns its standard output and standard error,
+// with a timeout.
+func dividedOutputTimeout(cmd *exec.Cmd) (stdout []byte, stderr []byte, err error) {
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = runTimeout(cmd)
+	return outBuf.Bytes(), errBuf.Bytes(), err
+}
+
+// runTimeout starts the specified command and waits for it to complete,
+// up to a timeout.
+func runTimeout(cmd *exec.Cmd) error {
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+	t := time.AfterFunc(timeout, func() {
+		cmd.Process.Signal(syscall.SIGTERM)
+	})
+	defer t.Stop()
+	return cmd.Wait()
 }

--- a/util.go
+++ b/util.go
@@ -2,8 +2,8 @@ package vcsstate
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
-	"syscall"
 	"time"
 )
 
@@ -37,7 +37,7 @@ func runTimeout(cmd *exec.Cmd) error {
 		return err
 	}
 	t := time.AfterFunc(timeout, func() {
-		cmd.Process.Signal(syscall.SIGTERM)
+		cmd.Process.Signal(os.Interrupt)
 	})
 	defer t.Stop()
 	return cmd.Wait()


### PR DESCRIPTION
This should help if a remote server stalls and does not hang up in a long time.

Use a pretty conservative value of 10 seconds for timeout. `vcsstate` performs very lightweight operations, so 10 seconds should be more than enough time.
