### PR TITLE
Rewrite RemoteURL without git remote get-url.

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -6,6 +6,50 @@ import (
 	"testing"
 )
 
+func TestParseGitRemote(t *testing.T) {
+	tests := []struct {
+		in      []byte
+		want    string
+		wantErr error
+	}{
+		{
+			in: []byte(`foo	https://github.com/foo/vcsstate (fetch)
+foo	https://github.com/foo/vcsstate (push)
+origin	https://github.com/shurcooL/vcsstate (fetch)
+origin	https://github.com/shurcooL/vcsstate (push)
+somebody	https://github.com/somebody/vcsstate (fetch)
+somebody	https://github.com/somebody/vcsstate (push)
+`),
+			want: "https://github.com/shurcooL/vcsstate",
+		},
+		{
+			in:      []byte(""),
+			wantErr: errors.New("no origin remote"),
+		},
+		// Only accept "origin" remote, even if others exist.
+		{
+			in: []byte(`fork	https://github.com/foobar/vcsstate (fetch)
+fork	https://github.com/foobar/vcsstate (push)
+`),
+			wantErr: errors.New("no origin remote"),
+		},
+	}
+
+	for _, test := range tests {
+		url, err := parseGitRemote(test.in)
+		if got, want := err, test.wantErr; !reflect.DeepEqual(got, want) {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if test.wantErr != nil {
+			continue
+		}
+
+		if got, want := url, test.want; got != want {
+			t.Errorf("got url %q, want %q", got, want)
+		}
+	}
+}
+
 func TestParseGitLsRemote(t *testing.T) {
 	tests := []struct {
 		in           []byte
@@ -49,10 +93,10 @@ f93697607c2406ba00b57fe418f4101b4e447eb8	refs/heads/numbers
 		}
 
 		if got, want := branch, test.wantBranch; got != want {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("got branch %q, want %q", got, want)
 		}
 		if got, want := revision, test.wantRevision; got != want {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("got revision %q, want %q", got, want)
 		}
 	}
 }


### PR DESCRIPTION
`git remote get-url` is only available in git 2.7, which is fairly recent. It's
possible to rewrite the same functionality using `git remote -v`, which
is available as far back as git 1.7 (and probably older):
-   https://git-scm.com/docs/git-remote/2.7.0
-   https://git-scm.com/docs/git-remote/1.7.12.2

Updates #4.
Fixes #3.
