### PR TITLE
Add default branch parameter to RemoteContains.

### DIFF
--- a/git17.go
+++ b/git17.go
@@ -96,8 +96,8 @@ func (git17) Contains(dir string, revision string, defaultBranch string) (bool, 
 	}
 }
 
-func (git17) RemoteContains(dir string, revision string) (bool, error) {
-	cmd := exec.Command("git", "branch", "-r", "--contains", revision, "origin/HEAD")
+func (git17) RemoteContains(dir string, revision string, defaultBranch string) (bool, error) {
+	cmd := exec.Command("git", "branch", "-r", "--contains", revision, "origin/"+defaultBranch)
 	cmd.Dir = dir
 	env := osutil.Environ(os.Environ())
 	env.Set("LANG", "en_US.UTF-8")

--- a/git28.go
+++ b/git28.go
@@ -100,9 +100,9 @@ func (git28) Contains(dir string, revision string, defaultBranch string) (bool, 
 	}
 }
 
-func (git28) RemoteContains(dir string, revision string) (bool, error) {
+func (git28) RemoteContains(dir string, revision string, defaultBranch string) (bool, error) {
 	// --format=contains is just an arbitrary constant string that we look for in the output.
-	cmd := exec.Command("git", "for-each-ref", "--format=contains", "--count=1", "--contains", revision, "refs/remotes/origin/HEAD")
+	cmd := exec.Command("git", "for-each-ref", "--format=contains", "--count=1", "--contains", revision, "refs/remotes/origin/"+defaultBranch)
 	cmd.Dir = dir
 	env := osutil.Environ(os.Environ())
 	env.Set("LANG", "en_US.UTF-8")

--- a/hg.go
+++ b/hg.go
@@ -100,7 +100,7 @@ func (hg) Contains(dir string, revision string, defaultBranch string) (bool, err
 	}
 }
 
-func (hg) RemoteContains(dir string, revision string) (bool, error) {
+func (hg) RemoteContains(dir string, revision string, defaultBranch string) (bool, error) {
 	return false, errors.New("not implemented for hg")
 }
 

--- a/vcsstate.go
+++ b/vcsstate.go
@@ -43,7 +43,7 @@ type VCS interface {
 
 	// RemoteContains reports whether the remote default branch contains
 	// the commit specified by revision.
-	RemoteContains(dir string, revision string) (bool, error)
+	RemoteContains(dir string, revision string, defaultBranch string) (bool, error)
 
 	// RemoteURL returns primary remote URL, as set in the local repository.
 	// If there's no remote, then ErrNoRemote is returned.


### PR DESCRIPTION
This is a necessary breaking API change to achieve improved reliability.

Some git repositories will not have the refs/remotes/origin/HEAD ref, see https://stackoverflow.com/questions/17639383/how-to-add-missing-origin-head-in-git-repo:

> The origin's `HEAD` is only fetched when you clone the repo. If you otherwise add the remote (e.g., by using `git remote add` or by renaming another existing remote), this ref will not exist.

Therefore, the sensible thing to do is require the caller to provide the default branch via a parameter, similar to [`Contains`](https://godoc.org/github.com/shurcooL/vcsstate#VCS.Contains) method. In most cases, it will be easy and inexpensive for caller to do that, since it'll have fetched the default branch by that point.